### PR TITLE
Added dynamic finder 'find_by_email' as class method

### DIFF
--- a/lib/devise/multi_email/models/authenticatable.rb
+++ b/lib/devise/multi_email/models/authenticatable.rb
@@ -82,6 +82,10 @@ module Devise
             raise "#{self.class.name}: Association :#{EMAILS_ASSOCIATION} not found: It might because your declaration is after `devise :multi_email_confirmable`."
           end
         end
+        
+        def find_by_email(email)
+          joins(:emails).where(emails: {email: email.downcase}).first
+        end
       end
     end
   end

--- a/spec/multi_email_spec.rb
+++ b/spec/multi_email_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe 'Devise Mutil Email' do
         expect(user.email).to eq(nil)
       end
     end
+
+    describe 'find_by_email()' do
+      let(:user) { create_user }
+
+      it 'returns user from email' do
+        expect(User.find_by_email(user.email)).to eq(user)
+      end
+    end
   end
 
   describe 'Validatable' do

--- a/spec/multi_email_spec.rb
+++ b/spec/multi_email_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Devise Mutil Email' do
       end
     end
 
-    describe 'find_by_email()' do
+    describe '.find_by_email()' do
       let(:user) { create_user }
 
       it 'returns user from email' do


### PR DESCRIPTION
Rails automatically adds a dynamic finder method for every field defined in a table. Thus, usually, we have a `find_by_email` method, this is lost when we remove the `email` column. 

This PR brings back this functionality. 