### PR TITLE
Configurable association names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
+### 2.0.0 - 2017-05-12
+
+* New `Devise::MultiEmail#configure` setup with options for `user` and `emails` associations and `primary_email` method names
+* Refactor to expose `_multi_email_*` prefixed methods on models
+
 ### 1.0.5 - 2016-12-29
-* New `.find_by_email` method. Thanks to [mrjlynch](https://github.com/mrjlynch). 
+
+* New `.find_by_email` method. Thanks to [mrjlynch](https://github.com/mrjlynch).
 
 ### 1.0.4 - 2016-08-13
+
 * Bug fix: Case-insentive configuration of email is ignored (#1). Thanks to [@fonglh](https://github.com/fonglh).
 
 ### 1.0.3 - 2016-02-18
 
-* Bug fix: Fix a wrong error message which shows "Email can't be blank" when email does not exist. 
+* Bug fix: Fix a wrong error message which shows "Email can't be blank" when email does not exist.
 
 ### 1.0.2 - 2016-01-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * New `Devise::MultiEmail#configure` setup with options for `user` and `emails` associations and `primary_email` method names
 * Refactor to expose `_multi_email_*` prefixed methods on models
+* New `primary_email` method to get primary email record (however, can be configured as `primary_email_record` for backwards-compatibility)
+* Changed logic when changing an email address to look up existing email record, otherwise creating a new one, then marking it "primary"
+* Changed logic when changing an email address to mark all others as `primary = false`
+* Changed logic when changing an email address to `nil` to mark as `primary = false` rather than deleting records
 
 ### 1.0.5 - 2016-12-29
 

--- a/README.md
+++ b/README.md
@@ -53,12 +53,15 @@ create_table :emails do |t|
 
 You may not want to use the association `user.emails` or `email.users`. You can customize the name of the associations used.
 
-```ruby
-# Default is :user for Email model
-Devise::MultiEmail.parent_association_name = :team
+_Note: model classes are inferred from the associations._
 
-# Default is :emails for User model
-Devise::MultiEmail.emails_association_name = :email_addresses
+```ruby
+Devise::MultiEmail.configure do |config|
+  # Default is :user for Email model
+  config.parent_association_name = :team
+  # Default is :emails for parent (e.g. User) model
+  config.emails_association_name = :email_addresses
+end
 
 # Example use of custom association names
 team = Team.first

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ create_table :emails do |t|
 
 ### Configure custom association names
 
-You may not want to use the association `user.emails` or `email.users`. You can customize the name of the associations used.
+You may not want to use the association `user.emails` or `email.users`. You can customize the name of the associations used. Add your custom configurations to an initializer file such as `config/initializers/devise-multi_email.rb`.
 
 _Note: model classes are inferred from the associations._
 
@@ -61,6 +61,9 @@ Devise::MultiEmail.configure do |config|
   config.parent_association_name = :team
   # Default is :emails for parent (e.g. User) model
   config.emails_association_name = :email_addresses
+  # For backwards-compatibility, specify :primary_email_record
+  # Default is :primary_email
+  config.primary_email_method_name = :primary_email_record
 end
 
 # Example use of custom association names

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # Devise::MultiEmail [![Build Status](https://travis-ci.org/allenwq/devise-multi_email.svg?branch=master)](https://travis-ci.org/allenwq/devise-multi_email) [![Coverage Status](https://coveralls.io/repos/allenwq/devise-multi_email/badge.svg?branch=master&service=github)](https://coveralls.io/github/allenwq/devise-multi_email?branch=master)
 
-Let [devise](https://github.com/plataformatec/devise) support multilpe emails, it allows you to:
+Letting [Devise](https://github.com/plataformatec/devise) support multiple emails, allows you to:
 - Login with multiple emails
 - Send confirmations to multiple emails
 - Recover the password with any of the emails
 - Validations for multiple emails
 
-`:multi_email_authenticatable`, `:multi_email_confirmable` and `:multi_email_validatable` are provided by devise-multi_email.
+`:multi_email_authenticatable`, `:multi_email_confirmable` and `:multi_email_validatable` are provided by _devise-multi_email_.
 
 ## Getting Started
 
-Add this line to your application's Gemfile, devise-multi_email has been tested with devise 4.0 and rails 4.2:
+Add this line to your application's `Gemfile`, _devise-multi_email_ has been tested with Devise 4.0 and rails 4.2:
 
 ```ruby
 gem 'devise-multi_email'
 ```
 
-Suppose you have already setup devise, your `User` model might look like this:
+Suppose you have already setup Devise, your `User` model might look like this:
 
 ```ruby
 class User < ActiveRecord::Base
@@ -24,7 +24,7 @@ class User < ActiveRecord::Base
 end
 ```
 
-In order to let your `User` support multiple emails, with `devise-multi_email` what you need to do is just:
+In order to let your `User` support multiple emails, with _devise-multi_email_ what you need to do is just:
 
 ```ruby
 class User < ActiveRecord::Base
@@ -39,7 +39,8 @@ class Email < ActiveRecord::Base
 end
 ```
 
-Note that `:email` column should be moved from users table to the emails table, and a new `primary` boolean column should be added to the emails table (so that all the emails will be sent to the primary email, and `user.email` will give you the primary email address). Your emails table's migration should look like:
+Note that the `:email` column should be moved from `users` table to the `emails` table, and a new `primary` boolean column should be added to the `emails` table (so that all the emails will be sent to the primary email, and `user.email` will give you the primary email address). Your `emails` table's migration should look like:
+
 ```ruby
 create_table :emails do |t|
   t.integer :user_id
@@ -48,20 +49,42 @@ create_table :emails do |t|
  end
 ```
 
+### Configure custom association names
+
+You may not want to use the association `user.emails` or `email.users`. You can customize the name of the associations used.
+
+```ruby
+# Default is :user for Email model
+Devise::MultiEmail.parent_association_name = :team
+
+# Default is :emails for User model
+Devise::MultiEmail.emails_association_name = :email_addresses
+
+# Example use of custom association names
+team = Team.first
+emails = team.email_addresses
+
+email = EmailAddress.first
+team = email.team
+```
+
 ## Confirmable with multiple emails
-Sending different confirmaitons to different emails is supported. What you need to do is:
+
+Sending separate confirmations to each email is supported. What you need to do is:
 
 Declare `devise :multi_email_confirmable` in your `User` model:
+
 ```ruby
 class User < ActiveRecord::Base
   has_many :emails
 
-  # You should not declare :confiramble and :multi_email_confirmable at the same time.
+  # You should not declare :confirmable and :multi_email_confirmable at the same time.
   devise :multi_email_authenticatable, :registerable, :multi_email_confirmable
 end
 ```
 
-Add `:confirmation_token`, `:confirmed_at` and `:confirmation_sent_at` to your emails table:
+Add `:confirmation_token`, `:confirmed_at` and `:confirmation_sent_at` to your `emails` table:
+
 ```ruby
 create_table :emails do |t|
   t.integer :user_id
@@ -70,16 +93,17 @@ create_table :emails do |t|
 
   ## Confirmable
   t.string :unconfirmed_email
-  t.string   :confirmation_token
+  t.string :confirmation_token
   t.datetime :confirmed_at
   t.datetime :confirmation_sent_at
 end
 ```
 
-Then all the methods in devise confirmable are avalible in your `Email` model. You can do `Email#send_confirmation_instructions` for each of your email. And `User#send_confirmation_instructions` will be delegated to the primary email.
+Then all the methods in Devise confirmable are available in your `Email` model. You can do `email#send_confirmation_instructions` for each of your email. And `user#send_confirmation_instructions` will be delegated to the primary email.
 
 ## Validatable with multiple emails
-Declare `devise :multi_email_validatable` in the user model, then all the user emails will be validated:
+
+Declare `devise :multi_email_validatable` in the `User` model, then all the user emails will be validated:
 
 ```ruby
 class User < ActiveRecord::Base
@@ -90,14 +114,14 @@ class User < ActiveRecord::Base
 end
 ```
 
-You can find the detail configurations in the [rails 5 example app](https://github.com/allenwq/devise-multi_email/tree/master/examples/rails5_app)
+You can find the detailed configurations in the [rails 5 example app](https://github.com/allenwq/devise-multi_email/tree/master/examples/rails5_app).
 
 ## ActiveJob Integration
 
-The [devise readme](https://github.com/plataformatec/devise#activejob-integration) describes how to use ActiveJob to deliver emails in the background. Normally you would place the following code in your `User` model, however when using devise-multi_email you should place this in the `Email` model.
+The [Devise README](https://github.com/plataformatec/devise#activejob-integration) describes how to use ActiveJob to deliver emails in the background. Normally you would place the following code in your `User` model, however when using _devise-multi_email_ you should place this in the `Email` model.
 
 ```ruby
-models/email.rb
+# models/email.rb
 def send_devise_notification(notification, *args)
   devise_mailer.send(notification, self, *args).deliver_later
 end
@@ -105,18 +129,23 @@ end
 
 ## What's more
 
-The gem works with all other devise modules just as normal, you don't need to add the `multi_email` prefix.
+The gem works with all other Devise modules as expected -- you don't need to add the "multi_email" prefix.
+
 ```ruby
+class User < ActiveRecord::Base
   devise :multi_email_authenticatable, :multi_email_confirmable, :multi_email_validatable, :lockable,
          :recoverable, :registerable, :rememberable, :timeoutable, :trackable
+end
 ```
 
 ## Issues
-You need to implement add/delete emails for a user as well as set/unset primary email.
 
-You can do `email.send_confirmation_instructions` for every email, but you also need to handle this logic in some place(excpet for the primary email). e.g. After a new email was added by a user, you might want to provide some buttons to allow user to resend confirmation instructions for that email.
+You need to implement add/delete emails for a user as well as set/unset "primary" for each email.
+
+You can do `email.send_confirmation_instructions` for each email individually, but you need to handle that logic in some place (except for the primary email, which is handled by Devise by default). e.g. After a new email was added by a user, you might want to provide some buttons in the view to allow users to resend confirmation instructions for that email.
 
 ## Wiki
+
 [Migrating exiting user records](https://github.com/allenwq/devise-multi_email/wiki/Migrating-existing-user-records)
 
 ## Development

--- a/lib/devise/multi_email.rb
+++ b/lib/devise/multi_email.rb
@@ -3,6 +3,11 @@ require 'devise'
 
 module Devise
   module MultiEmail
+
+    def self.configure(&block)
+      yield self
+    end
+
     def self.parent_association_name
       @parent_association_name ||= :user
     end

--- a/lib/devise/multi_email.rb
+++ b/lib/devise/multi_email.rb
@@ -36,14 +36,14 @@ module Devise
       extend ActiveSupport::Concern
 
       included do
-        _emails_association_class.send :include, EmailModelExtensions
+        _multi_email_emails_association_class.send :include, EmailModelExtensions
 
-        alias_method _primary_email_method_name, :_find_or_build_primary_email
+        alias_method _multi_email_primary_email_method_name, :_multi_email_find_or_build_primary_email
       end
 
       # Gets the primary email record.
-      def _find_or_build_primary_email
-        valid_emails = _emails_association.each.select do |email_record|
+      def _multi_email_find_or_build_primary_email
+        valid_emails = _multi_email_emails_association.each.select do |email_record|
           !email_record.destroyed? && !email_record.marked_for_destruction?
         end
 
@@ -52,33 +52,29 @@ module Devise
         result
       end
 
-      def _emails_association
-        __send__(self.class._emails_association_name)
+      def _multi_email_emails_association
+        __send__(self.class._multi_email_emails_association_name)
       end
 
       module ClassMethods
 
-        def _emails_association_class
-          unless _reflect_on_emails_association
+        def _multi_email_emails_association_class
+          unless _multi_email_reflect_on_emails_association
             raise "#{self}##{Devise::MultiEmail.emails_association_name} association not found: It might be because your declaration is after `devise :multi_email_confirmable`."
           end
 
-          @_emails_association_class ||= _reflect_on_emails_association.class_name.constantize
+          @_multi_email_emails_association_class ||= _multi_email_reflect_on_emails_association.class_name.constantize
         end
 
-        def _emails_association_table_name
-          @_emails_association_table_name ||= _reflect_on_emails_association.table_name
+        def _multi_email_reflect_on_emails_association
+          @_multi_email_reflect_on_emails_association ||= reflect_on_association(_multi_email_emails_association_name)
         end
 
-        def _reflect_on_emails_association
-          @_reflect_on_emails_association ||= reflect_on_association(_emails_association_name)
-        end
-
-        def _emails_association_name
+        def _multi_email_emails_association_name
           Devise::MultiEmail.emails_association_name
         end
 
-        def _primary_email_method_name
+        def _multi_email_primary_email_method_name
           Devise::MultiEmail.primary_email_method_name
         end
       end
@@ -87,29 +83,25 @@ module Devise
     module EmailModelExtensions
       extend ActiveSupport::Concern
 
-      def _parent_association
-        __send__(self.class._parent_association_name)
+      def _multi_email_parent_association
+        __send__(self.class._multi_email_parent_association_name)
       end
 
       module ClassMethods
 
-        def _parent_association_class
-          unless _reflect_on_parent_association
+        def _multi_email_parent_association_class
+          unless _multi_email_reflect_on_parent_association
             raise "#{self}##{Devise::MultiEmail.parent_association_name} association not found: It might be because your declaration is after `devise :multi_email_confirmable`."
           end
 
-          @_parent_association_class ||= _reflect_on_parent_association.class_name.constantize
+          @_multi_email_parent_association_class ||= _multi_email_reflect_on_parent_association.class_name.constantize
         end
 
-        def _parent_association_table_name
-          @_parent_association_table_name ||= _reflect_on_parent_association.table_name
+        def _multi_email_reflect_on_parent_association
+          @_multi_email_reflect_on_parent_association ||= reflect_on_association(_multi_email_parent_association_name)
         end
 
-        def _reflect_on_parent_association
-          @_reflect_on_parent_association ||= reflect_on_association(_parent_association_name)
-        end
-
-        def _parent_association_name
+        def _multi_email_parent_association_name
           Devise::MultiEmail.parent_association_name
         end
       end

--- a/lib/devise/multi_email.rb
+++ b/lib/devise/multi_email.rb
@@ -51,20 +51,20 @@ module Devise
         _multi_email_filtered_emails.find(&:primary?)
       end
 
-      def _multi_email_change_email_address(email_address)
+      def _multi_email_change_email_to(new_email)
         valid_emails = _multi_email_filtered_emails
-        formatted_email_address = self.class.send(:devise_parameter_filter).filter(email: email_address)[:email]
+        formatted_email = self.class.send(:devise_parameter_filter).filter(email: new_email)[:email]
 
         # mark none as primary when set to nil
-        if email_address.nil?
+        if new_email.nil?
           valid_emails.each{|record| record.primary = false}
 
         # select or create an email
         else
-          record = valid_emails.find{|record| record.email == formatted_email_address}
+          record = valid_emails.find{|record| record.email == formatted_email}
 
           unless record
-            record = _multi_email_emails_association.build(email: formatted_email_address)
+            record = _multi_email_emails_association.build(email: formatted_email)
             valid_emails << record
           end
 

--- a/lib/devise/multi_email.rb
+++ b/lib/devise/multi_email.rb
@@ -24,15 +24,25 @@ module Devise
       @emails_association_name = name.try(:to_sym)
     end
 
+    def self.primary_email_method_name
+      @primary_email_method_name ||= :primary_email
+    end
+
+    def self.primary_email_method_name=(name)
+      @primary_email_method_name = name.try(:to_sym)
+    end
+
     module ParentModelExtensions
       extend ActiveSupport::Concern
 
       included do
         _emails_association_class.send :include, EmailModelExtensions
+
+        alias_method _primary_email_method_name, :_find_or_build_primary_email
       end
 
       # Gets the primary email record.
-      def primary_email_record
+      def _find_or_build_primary_email
         valid_emails = _emails_association.each.select do |email_record|
           !email_record.destroyed? && !email_record.marked_for_destruction?
         end
@@ -66,6 +76,10 @@ module Devise
 
         def _emails_association_name
           Devise::MultiEmail.emails_association_name
+        end
+
+        def _primary_email_method_name
+          Devise::MultiEmail.primary_email_method_name
         end
       end
     end

--- a/lib/devise/multi_email.rb
+++ b/lib/devise/multi_email.rb
@@ -23,6 +23,83 @@ module Devise
     def self.emails_association_name=(name)
       @emails_association_name = name.try(:to_sym)
     end
+
+    module ParentModelExtensions
+      extend ActiveSupport::Concern
+
+      included do
+        _emails_association_class.send :include, EmailModelExtensions
+      end
+
+      # Gets the primary email record.
+      def primary_email_record
+        valid_emails = _emails_association.each.select do |email_record|
+          !email_record.destroyed? && !email_record.marked_for_destruction?
+        end
+
+        result = valid_emails.find(&:primary?)
+        result ||= valid_emails.first
+        result
+      end
+
+      def _emails_association
+        __send__(self.class._emails_association_name)
+      end
+
+      module ClassMethods
+
+        def _emails_association_class
+          unless _reflect_on_emails_association
+            raise "#{self}##{Devise::MultiEmail.emails_association_name} association not found: It might be because your declaration is after `devise :multi_email_confirmable`."
+          end
+
+          @_emails_association_class ||= _reflect_on_emails_association.class_name.constantize
+        end
+
+        def _emails_association_table_name
+          @_emails_association_table_name ||= _reflect_on_emails_association.table_name
+        end
+
+        def _reflect_on_emails_association
+          @_reflect_on_emails_association ||= reflect_on_association(_emails_association_name)
+        end
+
+        def _emails_association_name
+          Devise::MultiEmail.emails_association_name
+        end
+      end
+    end
+
+    module EmailModelExtensions
+      extend ActiveSupport::Concern
+
+      def _parent_association
+        __send__(self.class._parent_association_name)
+      end
+
+      module ClassMethods
+
+        def _parent_association_class
+          unless _reflect_on_parent_association
+            raise "#{self}##{Devise::MultiEmail.parent_association_name} association not found: It might be because your declaration is after `devise :multi_email_confirmable`."
+          end
+
+          @_parent_association_class ||= _reflect_on_parent_association.class_name.constantize
+        end
+
+        def _parent_association_table_name
+          @_parent_association_table_name ||= _reflect_on_parent_association.table_name
+        end
+
+        def _reflect_on_parent_association
+          @_reflect_on_parent_association ||= reflect_on_association(_parent_association_name)
+        end
+
+        def _parent_association_name
+          Devise::MultiEmail.parent_association_name
+        end
+      end
+    end
   end
 end
 

--- a/lib/devise/multi_email.rb
+++ b/lib/devise/multi_email.rb
@@ -1,6 +1,26 @@
 require 'devise/multi_email/version'
 require 'devise'
 
+module Devise
+  module MultiEmail
+    def self.parent_association_name
+      @parent_association_name ||= :user
+    end
+
+    def self.parent_association_name=(name)
+      @parent_association_name = name.try(:to_sym)
+    end
+
+    def self.emails_association_name
+      @emails_association_name ||= :emails
+    end
+
+    def self.emails_association_name=(name)
+      @emails_association_name = name.try(:to_sym)
+    end
+  end
+end
+
 Devise.add_module :multi_email_authenticatable, model: 'devise/multi_email/models/authenticatable'
 Devise.add_module :multi_email_confirmable, model: 'devise/multi_email/models/confirmable'
 Devise.add_module :multi_email_validatable, model: 'devise/multi_email/models/validatable'

--- a/lib/devise/multi_email.rb
+++ b/lib/devise/multi_email.rb
@@ -33,9 +33,6 @@ module Devise
   end
 end
 
-require 'devise/multi_email/email_model_extensions'
-require 'devise/multi_email/parent_model_extensions'
-
 Devise.add_module :multi_email_authenticatable, model: 'devise/multi_email/models/authenticatable'
 Devise.add_module :multi_email_confirmable, model: 'devise/multi_email/models/confirmable'
 Devise.add_module :multi_email_validatable, model: 'devise/multi_email/models/validatable'

--- a/lib/devise/multi_email.rb
+++ b/lib/devise/multi_email.rb
@@ -3,7 +3,6 @@ require 'devise'
 
 module Devise
   module MultiEmail
-
     def self.configure(&block)
       yield self
     end
@@ -31,115 +30,11 @@ module Devise
     def self.primary_email_method_name=(name)
       @primary_email_method_name = name.try(:to_sym)
     end
-
-    module ParentModelExtensions
-      extend ActiveSupport::Concern
-
-      included do
-        _multi_email_emails_association_class.send :include, EmailModelExtensions
-
-        alias_method _multi_email_primary_email_method_name, :_multi_email_find_primary_email
-      end
-
-      # Gets the primary email record.
-      def _multi_email_filtered_emails
-        _multi_email_emails_association.reject(&:destroyed?).reject(&:marked_for_destruction?)
-      end
-
-      # Gets the primary email record.
-      def _multi_email_find_primary_email
-        _multi_email_filtered_emails.find(&:primary?)
-      end
-
-      def _multi_email_change_email_to(new_email)
-        valid_emails = _multi_email_filtered_emails
-        formatted_email = self.class.send(:devise_parameter_filter).filter(email: new_email)[:email]
-
-        # mark none as primary when set to nil
-        if new_email.nil?
-          valid_emails.each{|record| record.primary = false}
-
-        # select or create an email
-        else
-          record = valid_emails.find{|record| record.email == formatted_email}
-
-          unless record
-            record = _multi_email_emails_association.build(email: formatted_email)
-            valid_emails << record
-          end
-
-          # toggle the selected record as primary and others as not
-          valid_emails.each{|other| other.primary = (other == record)}
-        end
-
-        # if new_email.present?
-        #   record ||= _multi_email_emails_association.build
-        #   record.email = new_email
-        #   # toggle primary to "true" for this record and "false" for the others
-        #   _multi_email_emails_association.each{|other| other.primary = (other == record)}
-        # elsif new_email.nil? && record
-        #   record.mark_for_destruction
-        # end
-
-        record
-      end
-
-      def _multi_email_emails_association
-        __send__(self.class._multi_email_emails_association_name)
-      end
-
-      module ClassMethods
-
-        def _multi_email_emails_association_class
-          unless _multi_email_reflect_on_emails_association
-            raise "#{self}##{Devise::MultiEmail.emails_association_name} association not found: It might be because your declaration is after `devise :multi_email_confirmable`."
-          end
-
-          @_multi_email_emails_association_class ||= _multi_email_reflect_on_emails_association.class_name.constantize
-        end
-
-        def _multi_email_reflect_on_emails_association
-          @_multi_email_reflect_on_emails_association ||= reflect_on_association(_multi_email_emails_association_name)
-        end
-
-        def _multi_email_emails_association_name
-          Devise::MultiEmail.emails_association_name
-        end
-
-        def _multi_email_primary_email_method_name
-          Devise::MultiEmail.primary_email_method_name
-        end
-      end
-    end
-
-    module EmailModelExtensions
-      extend ActiveSupport::Concern
-
-      def _multi_email_parent_association
-        __send__(self.class._multi_email_parent_association_name)
-      end
-
-      module ClassMethods
-
-        def _multi_email_parent_association_class
-          unless _multi_email_reflect_on_parent_association
-            raise "#{self}##{Devise::MultiEmail.parent_association_name} association not found: It might be because your declaration is after `devise :multi_email_confirmable`."
-          end
-
-          @_multi_email_parent_association_class ||= _multi_email_reflect_on_parent_association.class_name.constantize
-        end
-
-        def _multi_email_reflect_on_parent_association
-          @_multi_email_reflect_on_parent_association ||= reflect_on_association(_multi_email_parent_association_name)
-        end
-
-        def _multi_email_parent_association_name
-          Devise::MultiEmail.parent_association_name
-        end
-      end
-    end
   end
 end
+
+require 'devise/multi_email/email_model_extensions'
+require 'devise/multi_email/parent_model_extensions'
 
 Devise.add_module :multi_email_authenticatable, model: 'devise/multi_email/models/authenticatable'
 Devise.add_module :multi_email_confirmable, model: 'devise/multi_email/models/confirmable'

--- a/lib/devise/multi_email/association_manager.rb
+++ b/lib/devise/multi_email/association_manager.rb
@@ -1,0 +1,30 @@
+
+module Devise
+  module MultiEmail
+    class AssociationManager
+
+      attr_reader :name
+
+      def initialize(klass, association_name)
+        @klass = klass
+        @name = association_name
+      end
+
+      def include_module(mod)
+        model_class.__send__ :include, mod
+      end
+
+      def model_class
+        unless reflection
+          raise "#{@klass}##{name} association not found: It might be because your declaration is after `devise :multi_email_confirmable`."
+        end
+
+        @model_class ||= reflection.class_name.constantize
+      end
+
+      def reflection
+        @reflection ||= @klass.reflect_on_association(name)
+      end
+    end
+  end
+end

--- a/lib/devise/multi_email/email_model_extensions.rb
+++ b/lib/devise/multi_email/email_model_extensions.rb
@@ -1,0 +1,31 @@
+
+module Devise
+  module MultiEmail
+    module EmailModelExtensions
+      extend ActiveSupport::Concern
+
+      def _multi_email_parent_association
+        __send__(self.class._multi_email_parent_association_name)
+      end
+
+      module ClassMethods
+
+        def _multi_email_parent_association_class
+          unless _multi_email_reflect_on_parent_association
+            raise "#{self}##{Devise::MultiEmail.parent_association_name} association not found: It might be because your declaration is after `devise :multi_email_confirmable`."
+          end
+
+          @_multi_email_parent_association_class ||= _multi_email_reflect_on_parent_association.class_name.constantize
+        end
+
+        def _multi_email_reflect_on_parent_association
+          @_multi_email_reflect_on_parent_association ||= reflect_on_association(_multi_email_parent_association_name)
+        end
+
+        def _multi_email_parent_association_name
+          Devise::MultiEmail.parent_association_name
+        end
+      end
+    end
+  end
+end

--- a/lib/devise/multi_email/email_model_extensions.rb
+++ b/lib/devise/multi_email/email_model_extensions.rb
@@ -1,29 +1,18 @@
+require 'devise/multi_email/association_manager'
+require 'devise/multi_email/email_model_manager'
 
 module Devise
   module MultiEmail
     module EmailModelExtensions
       extend ActiveSupport::Concern
 
-      def _multi_email_parent_association
-        __send__(self.class._multi_email_parent_association_name)
+      def multi_email
+        @multi_email ||= EmailModelManager.new(self)
       end
 
       module ClassMethods
-
-        def _multi_email_parent_association_class
-          unless _multi_email_reflect_on_parent_association
-            raise "#{self}##{Devise::MultiEmail.parent_association_name} association not found: It might be because your declaration is after `devise :multi_email_confirmable`."
-          end
-
-          @_multi_email_parent_association_class ||= _multi_email_reflect_on_parent_association.class_name.constantize
-        end
-
-        def _multi_email_reflect_on_parent_association
-          @_multi_email_reflect_on_parent_association ||= reflect_on_association(_multi_email_parent_association_name)
-        end
-
-        def _multi_email_parent_association_name
-          Devise::MultiEmail.parent_association_name
+        def multi_email_association
+          @multi_email ||= AssociationManager.new(self, Devise::MultiEmail.parent_association_name)
         end
       end
     end

--- a/lib/devise/multi_email/email_model_manager.rb
+++ b/lib/devise/multi_email/email_model_manager.rb
@@ -1,0 +1,18 @@
+require 'devise/multi_email/email_model_extensions'
+
+module Devise
+  module MultiEmail
+    class EmailModelManager
+
+      attr_reader :record
+
+      def initialize(record)
+        @record = record
+      end
+
+      def parent
+        record.__send__(record.class.multi_email_association.name)
+      end
+    end
+  end
+end

--- a/lib/devise/multi_email/models/authenticatable.rb
+++ b/lib/devise/multi_email/models/authenticatable.rb
@@ -1,9 +1,6 @@
 module Devise
   module Models
     module EmailAuthenticatable
-      # deprecated
-      USER_ASSOCIATION = Devise::MultiEmail.parent_association_name
-
       def devise_scope
         self.class._parent_association_class
       end
@@ -11,8 +8,6 @@ module Devise
 
     module MultiEmailAuthenticatable
       extend ActiveSupport::Concern
-      # deprecated
-      EMAILS_ASSOCIATION = Devise::MultiEmail.emails_association_name
 
       included do
         include Devise::MultiEmail::ParentModelExtensions

--- a/lib/devise/multi_email/models/authenticatable.rb
+++ b/lib/devise/multi_email/models/authenticatable.rb
@@ -30,12 +30,12 @@ module Devise
 
       # Gets the primary email address of the user.
       def email
-        primary_email_record.try(:email)
+        _find_or_build_primary_email.try(:email)
       end
 
       # Sets the default email address of the user.
       def email=(email)
-        record = primary_email_record
+        record = _find_or_build_primary_email
         if email
           record ||= _emails_association.build
           record.email = email
@@ -47,7 +47,7 @@ module Devise
 
       # skip_confirmation on the users primary email
       def skip_confirmation!
-        primary_email_record.skip_confirmation!
+        _find_or_build_primary_email.skip_confirmation!
       end
 
       module ClassMethods

--- a/lib/devise/multi_email/models/authenticatable.rb
+++ b/lib/devise/multi_email/models/authenticatable.rb
@@ -33,7 +33,7 @@ module Devise
 
       # Gets the primary email record.
       def primary_email_record
-        valid_emails = emails.each.select do |email_record|
+        valid_emails = __send__(Devise::MultiEmail.emails_association_name).each.select do |email_record|
           !email_record.destroyed? && !email_record.marked_for_destruction?
         end
 
@@ -51,7 +51,7 @@ module Devise
       def email=(email)
         record = primary_email_record
         if email
-          record ||= emails.build
+          record ||= __send__(Devise::MultiEmail.emails_association_name).build
           record.email = email
           record.primary = true
         elsif email.nil? && record
@@ -71,9 +71,9 @@ module Devise
 
           if email && email.is_a?(String)
             conditions = filtered_conditions.to_h.merge(opts).
-              reverse_merge(emails: { email: email })
+              reverse_merge(Devise::MultiEmail.emails_association_name => { email: email })
 
-            resource = joins(:emails).find_by(conditions)
+            resource = joins(Devise::MultiEmail.emails_association_name).find_by(conditions)
             resource.current_login_email = email if resource.respond_to?(:current_login_email=)
             resource
           else
@@ -91,7 +91,7 @@ module Devise
         end
 
         def find_by_email(email)
-          joins(:emails).where(emails: {email: email.downcase}).first
+          joins(Devise::MultiEmail.emails_association_name).where(Devise::MultiEmail.emails_association_name => {email: email.downcase}).first
         end
       end
     end

--- a/lib/devise/multi_email/models/authenticatable.rb
+++ b/lib/devise/multi_email/models/authenticatable.rb
@@ -39,7 +39,7 @@ module Devise
 
         # Sets the default email address of the user.
         def email=(new_email)
-          _multi_email_change_email_address(new_email)
+          _multi_email_change_email_to(new_email)
         end
       end
 

--- a/lib/devise/multi_email/models/authenticatable.rb
+++ b/lib/devise/multi_email/models/authenticatable.rb
@@ -1,21 +1,23 @@
 module Devise
   module Models
     module EmailAuthenticatable
-      USER_ASSOCIATION = :user
+      # deprecated
+      USER_ASSOCIATION = Devise::MultiEmail.parent_association_name
 
       def devise_scope
-        user_association = self.class.reflect_on_association(USER_ASSOCIATION)
+        user_association = self.class.reflect_on_association(Devise::MultiEmail.parent_association_name)
         if user_association
           user_association.class_name.constantize
         else
-          raise "#{self.class.name}: Association :#{USER_ASSOCIATION} not found: Have you declared that ?"
+          raise "#{self.class.name}: Association :#{Devise::MultiEmail.parent_association_name} not found: Have you declared that ?"
         end
       end
     end
 
     module MultiEmailAuthenticatable
       extend ActiveSupport::Concern
-      EMAILS_ASSOCIATION = :emails
+      # deprecated
+      EMAILS_ASSOCIATION = Devise::MultiEmail.emails_association_name
 
       included do
         devise :database_authenticatable
@@ -80,14 +82,14 @@ module Devise
         end
 
         def email_class
-          email_association = reflect_on_association(EMAILS_ASSOCIATION)
+          email_association = reflect_on_association(Devise::MultiEmail.emails_association_name)
           if email_association
             email_association.class_name.constantize
           else
-            raise "#{self.class.name}: Association :#{EMAILS_ASSOCIATION} not found: It might because your declaration is after `devise :multi_email_confirmable`."
+            raise "#{self.class.name}: Association :#{Devise::MultiEmail.emails_association_name} not found: It might because your declaration is after `devise :multi_email_confirmable`."
           end
         end
-        
+
         def find_by_email(email)
           joins(:emails).where(emails: {email: email.downcase}).first
         end

--- a/lib/devise/multi_email/models/authenticatable.rb
+++ b/lib/devise/multi_email/models/authenticatable.rb
@@ -2,7 +2,7 @@ module Devise
   module Models
     module EmailAuthenticatable
       def devise_scope
-        self.class._parent_association_class
+        self.class._multi_email_parent_association_class
       end
     end
 
@@ -16,7 +16,7 @@ module Devise
 
         attr_accessor :current_login_email
 
-        _emails_association_class.send :include, EmailAuthenticatable
+        _multi_email_emails_association_class.send :include, EmailAuthenticatable
       end
 
       def self.required_fields(klass)
@@ -25,14 +25,14 @@ module Devise
 
       # Gets the primary email address of the user.
       def email
-        _find_or_build_primary_email.try(:email)
+        _multi_email_find_or_build_primary_email.try(:email)
       end
 
       # Sets the default email address of the user.
       def email=(email)
-        record = _find_or_build_primary_email
+        record = _multi_email_find_or_build_primary_email
         if email
-          record ||= _emails_association.build
+          record ||= _multi_email_emails_association.build
           record.email = email
           record.primary = true
         elsif email.nil? && record
@@ -42,7 +42,7 @@ module Devise
 
       # skip_confirmation on the users primary email
       def skip_confirmation!
-        _find_or_build_primary_email.skip_confirmation!
+        _multi_email_find_or_build_primary_email.skip_confirmation!
       end
 
       module ClassMethods
@@ -52,9 +52,9 @@ module Devise
 
           if email && email.is_a?(String)
             conditions = filtered_conditions.to_h.merge(opts).
-              reverse_merge(_emails_association_table_name => { email: email })
+              reverse_merge(_multi_email_reflect_on_emails_association.table_name => { email: email })
 
-            resource = joins(_emails_association_name).find_by(conditions)
+            resource = joins(_multi_email_emails_association_name).find_by(conditions)
             resource.current_login_email = email if resource.respond_to?(:current_login_email=)
             resource
           else
@@ -63,7 +63,7 @@ module Devise
         end
 
         def find_by_email(email)
-          joins(_emails_association_name).where(_emails_association_table_name => {email: email.downcase}).first
+          joins(_multi_email_emails_association_name).where(_multi_email_reflect_on_emails_association.table_name => {email: email.downcase}).first
         end
       end
     end

--- a/lib/devise/multi_email/models/authenticatable.rb
+++ b/lib/devise/multi_email/models/authenticatable.rb
@@ -61,7 +61,7 @@ module Devise
         end
 
         def find_by_email(email)
-          joins(_multi_email_emails_association_name).where(_multi_email_reflect_on_emails_association.table_name => {email: email.downcase}).first
+          joins(_multi_email_emails_association_name).where(_multi_email_reflect_on_emails_association.table_name => { email: email.downcase }).first
         end
       end
     end

--- a/lib/devise/multi_email/models/authenticatable.rb
+++ b/lib/devise/multi_email/models/authenticatable.rb
@@ -1,3 +1,5 @@
+require 'devise/multi_email/parent_model_extensions'
+
 module Devise
   module Models
     module EmailAuthenticatable

--- a/lib/devise/multi_email/models/authenticatable.rb
+++ b/lib/devise/multi_email/models/authenticatable.rb
@@ -39,7 +39,7 @@ module Devise
 
         # Sets the default email address of the user.
         def email=(new_email)
-          _multi_email_change_email_to(new_email)
+          _multi_email_change_primary_email_to(new_email)
         end
       end
 

--- a/lib/devise/multi_email/models/confirmable.rb
+++ b/lib/devise/multi_email/models/confirmable.rb
@@ -35,7 +35,7 @@ module Devise
         extend ActiveSupport::Concern
 
         included do
-          _emails_association_class.send :include, EmailConfirmable
+          _multi_email_emails_association_class.send :include, EmailConfirmable
         end
 
         # delegate before creating overriding methods
@@ -88,12 +88,12 @@ module Devise
 
         def current_login_email_record
           if respond_to?(:current_login_email) && current_login_email
-            _emails_association.find_by(email: current_login_email)
+            _multi_email_emails_association.find_by(email: current_login_email)
           end
         end
 
         module ClassMethods
-          delegate :confirm_by_token, :send_confirmation_instructions, to: :_emails_association_class, allow_nil: false
+          delegate :confirm_by_token, :send_confirmation_instructions, to: :_multi_email_emails_association_class, allow_nil: false
         end
       end
     end

--- a/lib/devise/multi_email/models/confirmable.rb
+++ b/lib/devise/multi_email/models/confirmable.rb
@@ -81,7 +81,7 @@ module Devise
 
         def current_login_email_record
           if respond_to?(:current_login_email) && current_login_email
-            send(Devise::MultiEmail.emails_association_name).find_by(email: current_login_email)
+            __send__(Devise::MultiEmail.emails_association_name).find_by(email: current_login_email)
           end
         end
       end

--- a/lib/devise/multi_email/models/confirmable.rb
+++ b/lib/devise/multi_email/models/confirmable.rb
@@ -81,7 +81,7 @@ module Devise
 
         def current_login_email_record
           if respond_to?(:current_login_email) && current_login_email
-            send(self.class::EMAILS_ASSOCIATION).find_by(email: current_login_email)
+            send(Devise::MultiEmail.emails_association_name).find_by(email: current_login_email)
           end
         end
       end

--- a/lib/devise/multi_email/models/confirmable.rb
+++ b/lib/devise/multi_email/models/confirmable.rb
@@ -37,7 +37,7 @@ module Devise
         extend ActiveSupport::Concern
 
         included do
-          _multi_email_emails_association_class.send :include, EmailConfirmable
+          multi_email_association.include_module(EmailConfirmable)
         end
 
         # delegate before creating overriding methods
@@ -90,12 +90,12 @@ module Devise
 
         def current_login_email_record
           if respond_to?(:current_login_email) && current_login_email
-            _multi_email_emails_association.find_by(email: current_login_email)
+            multi_email.emails.find_by(email: current_login_email)
           end
         end
 
         module ClassMethods
-          delegate :confirm_by_token, :send_confirmation_instructions, to: :_multi_email_emails_association_class, allow_nil: false
+          delegate :confirm_by_token, :send_confirmation_instructions, to: 'multi_email_association.model_class', allow_nil: false
         end
       end
     end

--- a/lib/devise/multi_email/models/confirmable.rb
+++ b/lib/devise/multi_email/models/confirmable.rb
@@ -1,3 +1,5 @@
+require 'devise/multi_email/parent_model_extensions'
+
 module Devise
   module Models
     module EmailConfirmable

--- a/lib/devise/multi_email/models/validatable.rb
+++ b/lib/devise/multi_email/models/validatable.rb
@@ -52,7 +52,7 @@ module Devise
 
         unless unavailable_validations.empty?
           raise "Could not use :validatable module since #{base} does not respond " <<
-                    "to the following methods: #{unavailable_validations.to_sentence}."
+                "to the following methods: #{unavailable_validations.to_sentence}."
         end
       end
 
@@ -71,8 +71,9 @@ module Devise
       private
 
       def propagate_email_errors
-        email_error_key = self.class::EMAILS_ASSOCIATION
-        if respond_to?("#{self.class::EMAILS_ASSOCIATION}_attributes=")
+        email_error_key = Devise::MultiEmail.emails_association_name
+
+        if respond_to?("#{email_error_key}_attributes=")
           email_error_key = "#{email_error_key}.email".to_sym
         end
 

--- a/lib/devise/multi_email/models/validatable.rb
+++ b/lib/devise/multi_email/models/validatable.rb
@@ -64,7 +64,7 @@ module Devise
           email_error_key = "#{email_error_key}.email".to_sym
         end
 
-        return if (email_errors = errors.delete(email_error_key)).nil?
+        email_errors = errors.delete(email_error_key) || []
 
         email_errors.each do |error|
           errors.add(:email, error)

--- a/lib/devise/multi_email/models/validatable.rb
+++ b/lib/devise/multi_email/models/validatable.rb
@@ -58,7 +58,7 @@ module Devise
     private
 
       def propagate_email_errors
-        email_error_key = Devise::MultiEmail.emails_association_name
+        email_error_key = self.class._multi_email_emails_association_name
 
         if respond_to?("#{email_error_key}_attributes=")
           email_error_key = "#{email_error_key}.email".to_sym

--- a/lib/devise/multi_email/models/validatable.rb
+++ b/lib/devise/multi_email/models/validatable.rb
@@ -33,8 +33,8 @@ module Devise
         validates_length_of       :password, within: password_length, allow_blank: true
 
         after_validation :propagate_email_errors
-        
-        _emails_association_class.send :include, EmailValidatable
+
+        _multi_email_emails_association_class.send :include, EmailValidatable
 
         devise_modules << :validatable
       end

--- a/lib/devise/multi_email/models/validatable.rb
+++ b/lib/devise/multi_email/models/validatable.rb
@@ -1,14 +1,12 @@
 module Devise
   module Models
     module EmailValidatable
-      def self.included(base)
-        base.extend ClassMethods
+      extend ActiveSupport::Concern
 
-        base.class_eval do
-          validates_presence_of   :email, if: :email_required?
-          validates_uniqueness_of :email, allow_blank: true, if: :email_changed?
-          validates_format_of     :email, with: email_regexp, allow_blank: true, if: :email_changed?
-        end
+      included do
+        validates_presence_of   :email, if: :email_required?
+        validates_uniqueness_of :email, allow_blank: true, if: :email_changed?
+        validates_format_of     :email, with: email_regexp, allow_blank: true, if: :email_changed?
       end
 
       def email_required?
@@ -21,42 +19,31 @@ module Devise
     end
 
     module MultiEmailValidatable
+      extend ActiveSupport::Concern
+
+      included do
+        include Devise::MultiEmail::ParentModelExtensions
+
+        assert_validations_api!(self)
+
+        validates_presence_of     :email, if: :email_required?
+
+        validates_presence_of     :password, if: :password_required?
+        validates_confirmation_of :password, if: :password_required?
+        validates_length_of       :password, within: password_length, allow_blank: true
+
+        after_validation :propagate_email_errors
+        
+        _emails_association_class.send :include, EmailValidatable
+
+        devise_modules << :validatable
+      end
+
       def self.required_fields(klass)
         []
       end
 
-      # All validations used by this module.
-      VALIDATIONS = [:validates_presence_of, :validates_uniqueness_of, :validates_format_of,
-                     :validates_confirmation_of, :validates_length_of].freeze
-
-      def self.included(base)
-        base.extend ClassMethods
-        assert_validations_api!(base)
-
-        base.class_eval do
-          validates_presence_of     :email, if: :email_required?
-
-          validates_presence_of     :password, if: :password_required?
-          validates_confirmation_of :password, if: :password_required?
-          validates_length_of       :password, within: password_length, allow_blank: true
-
-          after_validation :propagate_email_errors
-          email_class.send :include, EmailValidatable
-        end
-
-        base.devise_modules << :validatable
-      end
-
-      def self.assert_validations_api!(base) #:nodoc:
-        unavailable_validations = VALIDATIONS.select { |v| !base.respond_to?(v) }
-
-        unless unavailable_validations.empty?
-          raise "Could not use :validatable module since #{base} does not respond " <<
-                "to the following methods: #{unavailable_validations.to_sentence}."
-        end
-      end
-
-      protected
+    protected
 
       # Same as Devise::Models::Validatable#password_required?
       def password_required?
@@ -68,7 +55,7 @@ module Devise
         true
       end
 
-      private
+    private
 
       def propagate_email_errors
         email_error_key = Devise::MultiEmail.emails_association_name
@@ -85,6 +72,20 @@ module Devise
       end
 
       module ClassMethods
+
+        # All validations used by this module.
+        VALIDATIONS = [:validates_presence_of, :validates_uniqueness_of, :validates_format_of,
+                       :validates_confirmation_of, :validates_length_of].freeze
+
+        def assert_validations_api!(base) #:nodoc:
+          unavailable_validations = VALIDATIONS.select { |v| !base.respond_to?(v) }
+
+          unless unavailable_validations.empty?
+            raise "Could not use :validatable module since #{base} does not respond " <<
+                  "to the following methods: #{unavailable_validations.to_sentence}."
+          end
+        end
+
         Devise::Models.config(self, :password_length)
       end
     end

--- a/lib/devise/multi_email/models/validatable.rb
+++ b/lib/devise/multi_email/models/validatable.rb
@@ -78,7 +78,7 @@ module Devise
                        :validates_confirmation_of, :validates_length_of].freeze
 
         def assert_validations_api!(base) #:nodoc:
-          unavailable_validations = VALIDATIONS.select { |v| !base.respond_to?(v) }
+          unavailable_validations = VALIDATIONS.select{ |v| !base.respond_to?(v) }
 
           unless unavailable_validations.empty?
             raise "Could not use :validatable module since #{base} does not respond " <<

--- a/lib/devise/multi_email/models/validatable.rb
+++ b/lib/devise/multi_email/models/validatable.rb
@@ -36,7 +36,7 @@ module Devise
 
         after_validation :propagate_email_errors
 
-        _multi_email_emails_association_class.send :include, EmailValidatable
+        multi_email_association.include_module(EmailValidatable)
 
         devise_modules << :validatable
       end
@@ -60,7 +60,7 @@ module Devise
     private
 
       def propagate_email_errors
-        email_error_key = self.class._multi_email_emails_association_name
+        email_error_key = self.class.multi_email_association.name
 
         if respond_to?("#{email_error_key}_attributes=")
           email_error_key = "#{email_error_key}.email".to_sym

--- a/lib/devise/multi_email/models/validatable.rb
+++ b/lib/devise/multi_email/models/validatable.rb
@@ -1,3 +1,5 @@
+require 'devise/multi_email/parent_model_extensions'
+
 module Devise
   module Models
     module EmailValidatable

--- a/lib/devise/multi_email/parent_model_extensions.rb
+++ b/lib/devise/multi_email/parent_model_extensions.rb
@@ -1,0 +1,77 @@
+require 'devise/multi_email/email_model_extensions'
+
+module Devise
+  module MultiEmail
+    module ParentModelExtensions
+      extend ActiveSupport::Concern
+
+      included do
+        _multi_email_emails_association_class.send :include, EmailModelExtensions
+
+        alias_method _multi_email_primary_email_method_name, :_multi_email_find_primary_email
+      end
+
+      # Gets the email records that have not been deleted
+      def _multi_email_filtered_emails
+        _multi_email_emails_association.reject(&:destroyed?).reject(&:marked_for_destruction?)
+      end
+
+      # Gets the primary email record.
+      def _multi_email_find_primary_email
+        _multi_email_filtered_emails.find(&:primary?)
+      end
+
+      def _multi_email_change_email_to(new_email)
+        valid_emails = _multi_email_filtered_emails
+        # Use Devise formatting settings for emails
+        formatted_email = self.class.send(:devise_parameter_filter).filter(email: new_email)[:email]
+
+        # mark none as primary when set to nil
+        if new_email.nil?
+          valid_emails.each{ |record| record.primary = false }
+
+        # select or build an email record
+        else
+          record = valid_emails.find{ |record| record.email == formatted_email }
+
+          unless record
+            record = _multi_email_emails_association.build(email: formatted_email)
+            valid_emails << record
+          end
+
+          # toggle the selected record as primary and others as not
+          valid_emails.each{ |other| other.primary = (other == record) }
+        end
+
+        record
+      end
+
+      def _multi_email_emails_association
+        __send__(self.class._multi_email_emails_association_name)
+      end
+
+      module ClassMethods
+
+        def _multi_email_emails_association_class
+          unless _multi_email_reflect_on_emails_association
+            raise "#{self}##{Devise::MultiEmail.emails_association_name} association not found: It might be because your declaration is after `devise :multi_email_confirmable`."
+          end
+
+          @_multi_email_emails_association_class ||= _multi_email_reflect_on_emails_association.class_name.constantize
+        end
+
+        def _multi_email_reflect_on_emails_association
+          @_multi_email_reflect_on_emails_association ||= reflect_on_association(_multi_email_emails_association_name)
+        end
+
+        def _multi_email_emails_association_name
+          Devise::MultiEmail.emails_association_name
+        end
+
+        def _multi_email_primary_email_method_name
+          Devise::MultiEmail.primary_email_method_name
+        end
+      end
+    end
+  end
+end

--- a/lib/devise/multi_email/parent_model_extensions.rb
+++ b/lib/devise/multi_email/parent_model_extensions.rb
@@ -1,4 +1,6 @@
 require 'devise/multi_email/email_model_extensions'
+require 'devise/multi_email/association_manager'
+require 'devise/multi_email/parent_model_manager'
 
 module Devise
   module MultiEmail
@@ -6,70 +8,18 @@ module Devise
       extend ActiveSupport::Concern
 
       included do
-        _multi_email_emails_association_class.send :include, EmailModelExtensions
-
-        alias_method _multi_email_primary_email_method_name, :_multi_email_find_primary_email
+        multi_email_association.include_module(EmailModelExtensions)
       end
+      
+      delegate Devise::MultiEmail.primary_email_method_name, to: :multi_email, allow_nil: false
 
-      # Gets the email records that have not been deleted
-      def _multi_email_filtered_emails
-        _multi_email_emails_association.reject(&:destroyed?).reject(&:marked_for_destruction?)
-      end
-
-      # Gets the primary email record.
-      def _multi_email_find_primary_email
-        _multi_email_filtered_emails.find(&:primary?)
-      end
-
-      def _multi_email_change_primary_email_to(new_email)
-        valid_emails = _multi_email_filtered_emails
-        # Use Devise formatting settings for emails
-        formatted_email = self.class.send(:devise_parameter_filter).filter(email: new_email)[:email]
-
-        # mark none as primary when set to nil
-        if new_email.nil?
-          valid_emails.each{ |record| record.primary = false }
-
-        # select or build an email record
-        else
-          record = valid_emails.find{ |record| record.email == formatted_email }
-
-          unless record
-            record = _multi_email_emails_association.build(email: formatted_email)
-            valid_emails << record
-          end
-
-          # toggle the selected record as primary and others as not
-          valid_emails.each{ |other| other.primary = (other == record) }
-        end
-
-        record
-      end
-
-      def _multi_email_emails_association
-        __send__(self.class._multi_email_emails_association_name)
+      def multi_email
+        @multi_email ||= ParentModelManager.new(self)
       end
 
       module ClassMethods
-
-        def _multi_email_emails_association_class
-          unless _multi_email_reflect_on_emails_association
-            raise "#{self}##{Devise::MultiEmail.emails_association_name} association not found: It might be because your declaration is after `devise :multi_email_confirmable`."
-          end
-
-          @_multi_email_emails_association_class ||= _multi_email_reflect_on_emails_association.class_name.constantize
-        end
-
-        def _multi_email_reflect_on_emails_association
-          @_multi_email_reflect_on_emails_association ||= reflect_on_association(_multi_email_emails_association_name)
-        end
-
-        def _multi_email_emails_association_name
-          Devise::MultiEmail.emails_association_name
-        end
-
-        def _multi_email_primary_email_method_name
-          Devise::MultiEmail.primary_email_method_name
+        def multi_email_association
+          @multi_email ||= AssociationManager.new(self, Devise::MultiEmail.emails_association_name)
         end
       end
     end

--- a/lib/devise/multi_email/parent_model_extensions.rb
+++ b/lib/devise/multi_email/parent_model_extensions.rb
@@ -21,7 +21,7 @@ module Devise
         _multi_email_filtered_emails.find(&:primary?)
       end
 
-      def _multi_email_change_email_to(new_email)
+      def _multi_email_change_primary_email_to(new_email)
         valid_emails = _multi_email_filtered_emails
         # Use Devise formatting settings for emails
         formatted_email = self.class.send(:devise_parameter_filter).filter(email: new_email)[:email]

--- a/lib/devise/multi_email/parent_model_manager.rb
+++ b/lib/devise/multi_email/parent_model_manager.rb
@@ -1,0 +1,55 @@
+require 'devise/multi_email/email_model_extensions'
+
+module Devise
+  module MultiEmail
+    class ParentModelManager
+
+      attr_reader :record
+
+      def initialize(record)
+        @record = record
+      end
+
+      # Gets the email records that have not been deleted
+      def filtered_emails
+        emails.reject(&:destroyed?).reject(&:marked_for_destruction?)
+      end
+
+      # Gets the primary email record.
+      def primary_email
+        filtered_emails.find(&:primary?)
+      end
+      alias_method Devise::MultiEmail.primary_email_method_name, :primary_email
+
+      def change_primary_email_to(new_email)
+        # Use Devise formatting settings for emails
+        formatted_email = record.class.send(:devise_parameter_filter).filter(email: new_email)[:email]
+
+        valid_emails = filtered_emails
+
+        # mark none as primary when set to nil
+        if new_email.nil?
+          valid_emails.each{ |record| record.primary = false }
+
+        # select or build an email record
+        else
+          record = valid_emails.find{ |record| record.email == formatted_email }
+
+          unless record
+            record = emails.build(email: formatted_email)
+            valid_emails << record
+          end
+
+          # toggle the selected record as primary and others as not
+          valid_emails.each{ |other| other.primary = (other == record) }
+        end
+
+        record
+      end
+
+      def emails
+        record.__send__(record.class.multi_email_association.name)
+      end
+    end
+  end
+end

--- a/lib/devise/multi_email/version.rb
+++ b/lib/devise/multi_email/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module MultiEmail
-    VERSION = '1.0.5'
+    VERSION = "2.0.0"
   end
 end

--- a/spec/rails_app/config/initializers/devise-multi_email.rb
+++ b/spec/rails_app/config/initializers/devise-multi_email.rb
@@ -1,0 +1,5 @@
+
+Devise::MultiEmail.configure do |config|
+  # specify this for backwards-compatibility
+  config.primary_email_method_name = :primary_email_record
+end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -13,7 +13,7 @@ module RailsTestHelpers
   end
 
   def create_email(user, options = {})
-    email = user._emails_association.create!(
+    email = user._multi_email_emails_association.create!(
       email: options[:email] || "user_#{SecureRandom.hex}@test.com",
       created_at: Time.now.utc
     )

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -1,22 +1,19 @@
 module RailsTestHelpers
   def create_user(options={})
-    @user ||= begin
-      user = User.create!(
-          username: 'usertest',
-          email: options[:email] || "user_#{SecureRandom.hex}@test.com",
-          password: options[:password] || '12345678',
-          password_confirmation: options[:password] || '12345678',
-          created_at: Time.now.utc
-      )
-      user.primary_email_record.update_attribute(:confirmation_sent_at, options[:confirmation_sent_at]) if options[:confirmation_sent_at]
-      user.confirm unless options[:confirm] == false
-      user
-    end
+    user = User.create!(
+        username: 'usertest',
+        email: options[:email] || "user_#{SecureRandom.hex}@test.com",
+        password: options[:password] || '12345678',
+        password_confirmation: options[:password] || '12345678',
+        created_at: Time.now.utc
+    )
+    user.primary_email_record.update_attribute(:confirmation_sent_at, options[:confirmation_sent_at]) if options[:confirmation_sent_at]
+    user.confirm unless options[:confirm] == false
+    user
   end
 
   def create_email(user, options = {})
-    email = Email.create!(
-      user: user,
+    email = user._emails_association.create!(
       email: options[:email] || "user_#{SecureRandom.hex}@test.com",
       created_at: Time.now.utc
     )

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -13,7 +13,7 @@ module RailsTestHelpers
   end
 
   def create_email(user, options = {})
-    email = user._multi_email_emails_association.create!(
+    email = user.multi_email.emails.create!(
       email: options[:email] || "user_#{SecureRandom.hex}@test.com",
       created_at: Time.now.utc
     )


### PR DESCRIPTION
You can specify whether you want to use `Email#user` and `User#emails` or change those association names.