### PR TITLE
Keep validator_type when propagating email errors

### DIFF
--- a/spec/multi_email_spec.rb
+++ b/spec/multi_email_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe 'Devise Mutil Email' do
         user = UserWithNestedAttributes.new(username: 'user', email: 'inavlid_email@')
         expect(user).not_to be_valid
         expect(user.errors[:email]).to be_present
+        expect(user.errors.details[:email].first[:error]).to eq(:invalid) if user.errors.respond_to?(:details)
       end
     end
   end


### PR DESCRIPTION
Currently, the details of the validation errors are lost when propagating errors from the email association to the devise model. This PR fixes this issue.