### PR TITLE
Fix delegating methods in confirmable if renamed primary_email_record

### DIFF
--- a/lib/devise/multi_email/models/confirmable.rb
+++ b/lib/devise/multi_email/models/confirmable.rb
@@ -43,7 +43,7 @@ module Devise
         # delegate before creating overriding methods
         delegate :skip_confirmation!, :skip_confirmation_notification!, :skip_reconfirmation!, :confirmation_required?,
                  :confirmation_token, :confirmed_at, :confirmation_sent_at, :confirm, :confirmed?, :unconfirmed_email,
-                 :reconfirmation_required?, :pending_reconfirmation?, to: :primary_email_record, allow_nil: true
+                 :reconfirmation_required?, :pending_reconfirmation?, to: Devise::MultiEmail.primary_email_method_name, allow_nil: true
 
         # In case email updates are being postponed, don't change anything
         # when the postpone feature tries to switch things back


### PR DESCRIPTION
Fixes errors when using any of the `confirmable` methods if the user changes the default `primary_email_method_name`.