### PR TITLE
Don't use `lazy`

### DIFF
--- a/lib/devise/multi_email/parent_model_manager.rb
+++ b/lib/devise/multi_email/parent_model_manager.rb
@@ -62,7 +62,7 @@ module Devise
 
       # Gets the email records that have not been deleted
       def filtered_emails(options = {})
-        emails.lazy.reject(&:destroyed?).reject(&:marked_for_destruction?).to_a
+        emails.to_a.reject(&:destroyed?).reject(&:marked_for_destruction?)
       end
 
       def confirmed_emails


### PR DESCRIPTION
Using `lazy` is unnecessary. It also shouldn't be called on an Active Record relation. It can cause conflicts with other libraries that might add `lazy` as a class method because Active Record relations call class methods when attempting to chain scopes.