### PR TITLE
Update primary email if unconfirmed access allowed

### DIFF
--- a/lib/devise/multi_email/models/confirmable.rb
+++ b/lib/devise/multi_email/models/confirmable.rb
@@ -48,7 +48,7 @@ module Devise
         # In case email updates are being postponed, don't change anything
         # when the postpone feature tries to switch things back
         def email=(new_email)
-          multi_email.change_primary_email_to(new_email, allow_unconfirmed: false)
+          multi_email.change_primary_email_to(new_email, allow_unconfirmed: Devise.allow_unconfirmed_access_for > 0.days)
         end
 
         # This need to be forwarded to the email that the user logged in with

--- a/spec/features/confirmable_spec.rb
+++ b/spec/features/confirmable_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe 'Confirmable', type: :feature do
       end
 
       context 'with non-primary email' do
-        it 'shows the error message' do
+        it 'signs the user in' do
           user = create_user
           secondary_email = create_email(user, confirm: false)
           visit new_user_session_path
@@ -170,8 +170,8 @@ RSpec.describe 'Confirmable', type: :feature do
           fill_in 'user_password', with: '12345678'
           click_button 'Log in'
 
-          expect(current_path).to eq new_user_session_path
-          expect(page).to have_selector('div#flash_alert', text: 'You have to confirm your email address before continuing.')
+          expect(current_path).to eq root_path
+          expect(page).to have_selector('div', text: 'Signed in successfully.')
         end
       end
     end


### PR DESCRIPTION
It makes sense to me that confirmable should allow setting primary to true for a new record when allow_unconfirmed_access_for is set to greater than the default 0.days