### PR TITLE
Delegate confirmed_at= to primary_email

### DIFF
--- a/lib/devise/multi_email/models/confirmable.rb
+++ b/lib/devise/multi_email/models/confirmable.rb
@@ -42,7 +42,7 @@ module Devise
 
         # delegate before creating overriding methods
         delegate :skip_confirmation!, :skip_confirmation_notification!, :skip_reconfirmation!, :confirmation_required?,
-                 :confirmation_token, :confirmed_at, :confirmation_sent_at, :confirm, :confirmed?, :unconfirmed_email,
+                 :confirmation_token, :confirmed_at, :confirmed_at=, :confirmation_sent_at, :confirm, :confirmed?, :unconfirmed_email,
                  :reconfirmation_required?, :pending_reconfirmation?, to: Devise::MultiEmail.primary_email_method_name, allow_nil: true
 
         # In case email updates are being postponed, don't change anything


### PR DESCRIPTION
Devise Invitable [expects User to respond](https://github.com/scambra/devise_invitable/blob/master/lib/devise_invitable/models.rb#L98) to `confirmed_at=` if it responds to `confirmed_at`, which, admittedly, is a bit silly, but still this breaks multi_email + invitable. This should fix it without any backwards-incompatible impact.