### PR TITLE
Permit Devise.allow_unconfirmed_access to be nil

### DIFF
--- a/lib/devise/multi_email/models/confirmable.rb
+++ b/lib/devise/multi_email/models/confirmable.rb
@@ -48,7 +48,7 @@ module Devise
         # In case email updates are being postponed, don't change anything
         # when the postpone feature tries to switch things back
         def email=(new_email)
-          multi_email.change_primary_email_to(new_email, allow_unconfirmed: Devise.allow_unconfirmed_access_for > 0.days)
+          multi_email.change_primary_email_to(new_email, allow_unconfirmed: unconfirmed_access_possible?)
         end
 
         # This need to be forwarded to the email that the user logged in with
@@ -93,6 +93,11 @@ module Devise
         end
 
       private
+
+        def unconfirmed_access_possible?
+          Devise.allow_unconfirmed_access_for.nil? || \
+            Devise.allow_unconfirmed_access_for > 0.days
+        end
 
         module ClassMethods
           delegate :confirm_by_token, :send_confirmation_instructions, to: 'multi_email_association.model_class', allow_nil: false

--- a/spec/features/confirmable_spec.rb
+++ b/spec/features/confirmable_spec.rb
@@ -75,6 +75,22 @@ RSpec.describe 'Confirmable', type: :feature do
 
         expect(user.primary_email_record.email).to eq(new_email)
       end
+
+      context 'an unconfirmed access is indefinite' do
+        before do
+          Devise.setup do |config|
+            config.allow_unconfirmed_access_for = nil
+          end
+        end
+
+        it 'changes primary email to the new email' do
+          user = create_user
+          new_email = generate_email
+          user.email = new_email
+
+          expect(user.primary_email_record.email).to eq(new_email)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Background

Devise currently permits indefinite unconfirmed access when `Devise.allow_unconfirmed_access` is set to `nil`.

See:
https://github.com/plataformatec/devise/blob/14863ba4c92cd9781a961be0486f0ea7dfe84144/lib/generators/templates/devise.rb#L139-L140

However, at present setting this parameter to `nil` results in `NoMethodError`s when evaluating the following:

```ruby
def email=(new_email)
  multi_email.change_primary_email_to(new_email, allow_unconfirmed: Devise.allow_unconfirmed_access_for > 0.days)
end
```

### Change 

This PR creates a new method (`ConfirmableExtensions#unconfirmed_access_possible?`) that checks to ensure if the Devise configuration permits any period in which an unconfirmed user may log in.  This method is then used it to determine whether or not an unconfirmed email address may be added to a user.