### PR TITLE
Spec: Avoid .represent_boolean_as_integer= Deprecation warning in Rails 6+ - and make migrate work

### DIFF
--- a/spec/models/parent_model_manager_spec.rb
+++ b/spec/models/parent_model_manager_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe Devise::MultiEmail::ParentModelManager, type: :model do
   let(:new_email) { generate_email }
 
   describe 'multi_email API' do
+    describe '#current_email_record' do
+      it 'returns the primary email if not logged in' do
+        expect(user.multi_email.current_email_record).to be user.primary_email_record
+      end
+    end
+
     describe '#change_primary_email_to' do
       it 'un-sets primary email if given nil' do
         expect(user.primary_email_record).not_to be_nil

--- a/spec/multi_email_spec.rb
+++ b/spec/multi_email_spec.rb
@@ -101,4 +101,10 @@ RSpec.describe 'Devise Mutil Email' do
       end
     end
   end
+
+  describe 'the gem itself' do
+    it 'presents a VERSION' do
+      expect(Devise::MultiEmail::VERSION).to be_a(String)
+    end
+  end
 end

--- a/spec/orm/active_record.rb
+++ b/spec/orm/active_record.rb
@@ -1,8 +1,12 @@
 ActiveRecord::Migration.verbose = false
 
 migration_path = File.expand_path('../../rails_app/db/migrate/', __FILE__)
-if ActiveRecord.version.release < Gem::Version.new('5.2.0')
-  ActiveRecord::Migrator.migrate(migration_path)
-else
+# https://github.com/plataformatec/devise/blob/master/test/orm/active_record.rb
+# Run any available migration
+if Rails.version.start_with? '6'
+  ActiveRecord::MigrationContext.new(migration_path, ActiveRecord::SchemaMigration).migrate
+elsif Rails.version.start_with? '5.2'
   ActiveRecord::MigrationContext.new(migration_path).migrate
+else
+  ActiveRecord::Migrator.migrate(migration_path)
 end

--- a/spec/rails_app/config/environments/test.rb
+++ b/spec/rails_app/config/environments/test.rb
@@ -26,7 +26,7 @@ RailsApp::Application.configure do
     config.static_cache_control = 'public, max-age=3600'
   end
 
-  if Rails.version >= '5.2.0'
+  if Rails.version >= '5.2.0' && Rails.version < '6.0'
     config.active_record.sqlite3.represent_boolean_as_integer = true
   end
 


### PR DESCRIPTION
This PR adds a check to test.rb in the `rails_app` (dummy app): "Should we configure the boolean fields repr setting for Sqlite?"

**Avoids a warning** like:

> DEPRECATION WARNING: `.represent_boolean_as_integer=` is now always true, so setting this is  deprecated and will be removed in Rails 6.1. (called from <top (required)> at devise-multi_email/spec/rails_app/app/models/user.rb:1)

---

In addition, **makes migrate work**.
