### PR TITLE
Drop Gemfiles not run in tests

### DIFF
--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 4.2.8"
-
-gemspec path: "../"

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 5.0.3"
-gem 'sqlite3'
-
-gemspec path: "../"


### PR DESCRIPTION
This PR drops two Gemfiles which are no longer used in CI runs.

---

When I thought about #50, I found that these were unused.