### PR TITLE
CI: Add a Rails 6 gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /spec/rails_app/log/*
 /.ruby-version
 /.idea/
+/gemfiles/*gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ gemfile:
   - gemfiles/rails_5_2.gemfile
   - gemfiles/rails_5_1.gemfile
   - gemfiles/rails_6_0.gemfile
-before_install: gem install bundler
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+
 rvm:
   - 2.4
   - 2.5
@@ -7,4 +8,9 @@ gemfile:
   - gemfiles/rails_5_2.gemfile
   - gemfiles/rails_5_1.gemfile
   - gemfiles/rails_6_0.gemfile
+
+jobs:
+  exclude:
+    - rvm: 2.4
+      gemfile: gemfiles/rails_6_0.gemfile 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ rvm:
 gemfile:
   - gemfiles/rails_5_2.gemfile
   - gemfiles/rails_5_1.gemfile
+  - gemfiles/rails_6_0.gemfile
 before_install: gem install bundler

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Letting [Devise](https://github.com/plataformatec/devise) support multiple email
 
 ## Getting Started
 
-Add this line to your application's `Gemfile`, _devise-multi_email_ has been tested with Devise 4.0 and rails 4.2:
+Add this line to your application's `Gemfile`:
 
 ```ruby
 gem 'devise-multi_email'

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", ">= 6.0.2.1", "< 6.1"
+
+gemspec path: "../"


### PR DESCRIPTION
This PR adds a Rails 6 `Gemfile` and uses it in the CI build.

Details:

- installs Rails 6.0, but not on 2.4
- avoids _telling_ Travis which Bundler to use, to avoid conflicts.
- avoid referring to a Rails version in the README (which can become out of date)

Fixes #50 

No code changes!

