### PR TITLE
Fix ActiveModel::Errors#keys deprecation in Rails 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+* Fix ActiveModel::Errors#keys deprecation in Rails 6.1
+
 ### 3.0.0 - 2019-11-06
 * Deprecate the support of Rails 4 (although it might still work)
 * Fix warnings in Rails 6

--- a/lib/devise/multi_email/models/validatable.rb
+++ b/lib/devise/multi_email/models/validatable.rb
@@ -66,7 +66,7 @@ module Devise
 
       def propagate_email_errors
         association_name = self.class.multi_email_association.name
-        email_error_key = errors.keys.detect do |key|
+        email_error_key = errors_attribute_names.detect do |key|
           [association_name.to_s, "#{association_name}.email"].include?(key.to_s)
         end
         return unless email_error_key.present?
@@ -84,6 +84,10 @@ module Devise
         email_errors.each do |type, message|
           errors.add(:email, type, message: message)
         end
+      end
+
+      def errors_attribute_names
+        errors.respond_to?(:attribute_names) ? errors.attribute_names : errors.keys
       end
 
       module ClassMethods


### PR DESCRIPTION
The solution is backward compatible with all Rails versions present on CI (5.1 >=).

It solves https://github.com/allenwq/devise-multi_email/issues/67